### PR TITLE
Flexibility features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Compiled python modules.
 *.pyc
+build/
 
 # Setuptools distribution folder.
 /dist/

--- a/pythonrestclient/api/client_class.py
+++ b/pythonrestclient/api/client_class.py
@@ -5,10 +5,11 @@ from requests.auth import HTTPBasicAuth
 
 
 class ClientClass:
-    def __init__(self, base_url, username=None, password=None, custom_headers=None, wo_trailing=False):
+    def __init__(self, base_url, username=None, password=None, verify=True, custom_headers=None, wo_trailing=False):
         self.base_url = base_url
         self.username = username
         self.password = password
+        self.verify = verify
         self.custom_headers = custom_headers
         self.wo_trailing = wo_trailing
 
@@ -66,9 +67,9 @@ class ClientClass:
             kwargs['auth'] = HTTPBasicAuth(self.username, self.password)
         self._log_request(method, url, params, data, self.custom_headers)
         if data:
-            response = requests.request(method, url, headers=self.custom_headers, params=params, data=json.dumps(data), **kwargs)
+            response = requests.request(method, url, headers=self.custom_headers, params=params, data=json.dumps(data), verify=verify, **kwargs)
         else:
-            response = requests.request(method, url, headers=self.custom_headers, params=params, **kwargs)
+            response = requests.request(method, url, headers=self.custom_headers, params=params, verify=verify, **kwargs)
         self._check_response(response)
         return response
 

--- a/pythonrestclient/api/client_class.py
+++ b/pythonrestclient/api/client_class.py
@@ -5,62 +5,70 @@ from requests.auth import HTTPBasicAuth
 
 
 class ClientClass:
-    def __init__(self, base_url, username=None, password=None):
+    def __init__(self, base_url, username=None, password=None, custom_headers=None, wo_trailing=False):
         self.base_url = base_url
         self.username = username
         self.password = password
+        self.custom_headers = custom_headers
+        self.wo_trailing = wo_trailing
 
-    def get_resources(self, resources_name, params=None):
-        url = self._make_url('/{:s}/'.format(resources_name))
+    def get_resources(self, resources_name, params=None, url_format='/{:s}/'):
+        url = self._make_url(url_format.format(resources_name))
         response = self._make_get_request(url, params)
         self._log_response(response)
         return self.decoded_response(response)
 
-    def get(self, resources_name, resource_id):
-        url = self._make_url('/{:s}/{:d}/'.format(resources_name, int(resource_id)))
+    def get(self, resources_name, resource_id, url_format='/{:s}/{:d}/'):
+        url = self._make_url(url_format.format(resources_name, int(resource_id)))
         response = self._make_get_request(url)
         self._log_response(response)
         return self.decoded_response(response)
 
-    def post(self, resources_name, params):
-        url = self._make_url('/{:s}/'.format(resources_name))
-        response = self._make_post_request(url, params)
+    def post(self, resources_name, params=None, data=None, url_format='/{:s}/'):
+        url = self._make_url(url_format.format(resources_name))
+        response = self._make_post_request(url, params, data)
         self._log_response(response)
         return self.decoded_response(response)
 
-    def put(self, resources_name, resource_id, params):
-        url = self._make_url('/{:s}/{:d}/'.format(resources_name, int(resource_id)))
+    def put(self, resources_name, resource_id, params=None, data=None, url_format='/{:s}/{:d}/'):
+        url = self._make_url(url_format.format(resources_name, int(resource_id)))
         response = self._make_put_request(url, params)
         self._log_response(response)
         return self.decoded_response(response)
 
-    def delete(self, resources_name, resource_id):
-        url = self._make_url('/{:s}/{:d}/'.format(resources_name, int(resource_id)))
+    def delete(self, resources_name, resource_id, url_format='/{:s}/{:d}/'):
+        url = self._make_url(url_format.format(resources_name, int(resource_id)))
         response = self._make_delete_request(url)
         self._log_response(response)
         return self.decoded_response(response)
 
     def _make_url(self, path):
-        return self.base_url + path
+        url = self.base_url + path
+        if self.wo_trailing and url[-1] == '/':
+            return url[:-1]
+        return url
 
     def _make_get_request(self, url, params=None):
         return self._make_request('get', url, params)
 
-    def _make_post_request(self, url, params):
-        return self._make_request('post', url, params)
+    def _make_post_request(self, url, params=None, data=None):
+        return self._make_request('post', url, params, data)
 
-    def _make_put_request(self, url, params):
-        return self._make_request('put', url, params)
+    def _make_put_request(self, url, params=None, data=None):
+        return self._make_request('put', url, params, data)
 
     def _make_delete_request(self, url):
         return self._make_request('delete', url, None)
 
-    def _make_request(self, method, url, params):
+    def _make_request(self, method, url, params=None, data=None):
         kwargs = {}
         if self.username is not None:
             kwargs['auth'] = HTTPBasicAuth(self.username, self.password)
-        self._log_request(method, url, params)
-        response = requests.request(method, url, params=params, **kwargs)
+        self._log_request(method, url, params, data, self.custom_headers)
+        if data:
+            response = requests.request(method, url, headers=self.custom_headers, params=params, data=json.dumps(data), **kwargs)
+        else:
+            response = requests.request(method, url, headers=self.custom_headers, params=params, **kwargs)
         self._check_response(response)
         return response
 
@@ -78,9 +86,13 @@ class ClientClass:
     # TODO: print log to file
 
     @staticmethod
-    def _log_request(method, url, params):
-        print('\nMaking {:s} request to url="{:s}" with data:'.format(method, url))
+    def _log_request(method, url, params, data, headers):
+        print('\nMaking {:s} request to url="{:s}" with headers:'.format(method, url))
+        print(headers)
+        print(' and params:')
         print(params)
+        print(' and data:')
+        print(data)
 
     @staticmethod
     def _log_response(response):

--- a/pythonrestclient/api/client_class.py
+++ b/pythonrestclient/api/client_class.py
@@ -67,9 +67,9 @@ class ClientClass:
             kwargs['auth'] = HTTPBasicAuth(self.username, self.password)
         self._log_request(method, url, params, data, self.custom_headers)
         if data:
-            response = requests.request(method, url, headers=self.custom_headers, params=params, data=json.dumps(data), verify=verify, **kwargs)
+            response = requests.request(method, url, headers=self.custom_headers, params=params, data=json.dumps(data), verify=self.verify, **kwargs)
         else:
-            response = requests.request(method, url, headers=self.custom_headers, params=params, verify=verify, **kwargs)
+            response = requests.request(method, url, headers=self.custom_headers, params=params, verify=self.verify, **kwargs)
         self._check_response(response)
         return response
 

--- a/pythonrestclient/api/client_class.py
+++ b/pythonrestclient/api/client_class.py
@@ -96,8 +96,7 @@ class ClientClass:
     def decoded_response(response):
         return json.loads(response.text)
 
-    @staticmethod
-    def _log_request(method, url, params, data, headers):
+    def _log_request(self, method, url, params, data, headers):
         self.logger.debug('\nMaking {:s} request to url="{:s}" with headers:'.format(method, url))
         self.logger.debug(headers)
         self.logger.debug(' and params:')
@@ -105,6 +104,5 @@ class ClientClass:
         self.logger.debug(' and data:')
         self.logger.debug(data)
 
-    @staticmethod
-    def _log_response(response):
+    def _log_response(self, response):
         self.logger.debug('\nReceived response: status_code="{:d}" content="{:s}"'.format(response.status_code, response.content))

--- a/pythonrestclient/api/client_class.py
+++ b/pythonrestclient/api/client_class.py
@@ -1,17 +1,29 @@
 import requests
 import json
+import sys
 import errors
+import logging
 from requests.auth import HTTPBasicAuth
 
 
 class ClientClass:
-    def __init__(self, base_url, username=None, password=None, verify=True, custom_headers=None, wo_trailing=False):
+    def __init__(self, base_url, username=None, password=None, verify=True, custom_headers=None, wo_trailing=False, log_level=logging.CRITICAL, log_loc=sys.stdout):
         self.base_url = base_url
         self.username = username
         self.password = password
         self.verify = verify
         self.custom_headers = custom_headers
         self.wo_trailing = wo_trailing
+
+        # Set up logging
+        # Set up the global logger to stdout
+        self.logger = logging.getLogger(__name__)
+        ch = logging.StreamHandler(log_loc)
+        self.logger.setLevel(log_level)
+        ch.setLevel(log_level)
+        formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+        ch.setFormatter(formatter)
+        self.logger.addHandler(ch)
 
     def get_resources(self, resources_name, params=None, url_format='/{:s}/'):
         url = self._make_url(url_format.format(resources_name))
@@ -84,17 +96,15 @@ class ClientClass:
     def decoded_response(response):
         return json.loads(response.text)
 
-    # TODO: print log to file
-
     @staticmethod
     def _log_request(method, url, params, data, headers):
-        print('\nMaking {:s} request to url="{:s}" with headers:'.format(method, url))
-        print(headers)
-        print(' and params:')
-        print(params)
-        print(' and data:')
-        print(data)
+        self.logger.debug('\nMaking {:s} request to url="{:s}" with headers:'.format(method, url))
+        self.logger.debug(headers)
+        self.logger.debug(' and params:')
+        self.logger.debug(params)
+        self.logger.debug(' and data:')
+        self.logger.debug(data)
 
     @staticmethod
     def _log_response(response):
-        print('\nReceived response: status_code="{:d}" content="{:s}"'.format(response.status_code, response.content))
+        self.logger.debug('\nReceived response: status_code="{:d}" content="{:s}"'.format(response.status_code, response.content))

--- a/pythonrestclient/service_factory.py
+++ b/pythonrestclient/service_factory.py
@@ -1,3 +1,5 @@
+import sys
+import logging
 from api.client_class import ClientClass
 
 

--- a/pythonrestclient/service_factory.py
+++ b/pythonrestclient/service_factory.py
@@ -5,5 +5,5 @@ class ServiceFactory(object):
     api_client = None
 
     @classmethod
-    def init_api_client(cls, base_url, username=None, password=None):
-        cls.api_client = ClientClass(base_url, username, password)
+    def init_api_client(cls, base_url, username=None, password=None, custom_headers=None, wo_trailing=False):
+        cls.api_client = ClientClass(base_url, username, password, custom_headers, wo_trailing)

--- a/pythonrestclient/service_factory.py
+++ b/pythonrestclient/service_factory.py
@@ -7,5 +7,5 @@ class ServiceFactory(object):
     api_client = None
 
     @classmethod
-    def init_api_client(cls, base_url, username=None, password=None, verify=True, custom_headers=None, wo_trailing=False, log_level=logging.CRITICAL, log_loc=sys.stdout):
-        cls.api_client = ClientClass(base_url, username, password, verify, custom_headers, wo_trailing, log_level, log_loc)
+    def init_api_client(cls, base_url, username=None, password=None, verify=True, client_cert=None, custom_headers=None, wo_trailing=False, log_level=logging.CRITICAL, log_loc=sys.stdout):
+        cls.api_client = ClientClass(base_url, username, password, verify, client_cert, custom_headers, wo_trailing, log_level, log_loc)

--- a/pythonrestclient/service_factory.py
+++ b/pythonrestclient/service_factory.py
@@ -5,5 +5,5 @@ class ServiceFactory(object):
     api_client = None
 
     @classmethod
-    def init_api_client(cls, base_url, username=None, password=None, verify=True, custom_headers=None, wo_trailing=False):
-        cls.api_client = ClientClass(base_url, username, password, verify, custom_headers, wo_trailing)
+    def init_api_client(cls, base_url, username=None, password=None, verify=True, custom_headers=None, wo_trailing=False, log_level=logging.CRITICAL, log_loc=sys.stdout):
+        cls.api_client = ClientClass(base_url, username, password, verify, custom_headers, wo_trailing, log_level, log_loc)

--- a/pythonrestclient/service_factory.py
+++ b/pythonrestclient/service_factory.py
@@ -5,5 +5,5 @@ class ServiceFactory(object):
     api_client = None
 
     @classmethod
-    def init_api_client(cls, base_url, username=None, password=None, custom_headers=None, wo_trailing=False):
-        cls.api_client = ClientClass(base_url, username, password, custom_headers, wo_trailing)
+    def init_api_client(cls, base_url, username=None, password=None, verify=True, custom_headers=None, wo_trailing=False):
+        cls.api_client = ClientClass(base_url, username, password, verify, custom_headers, wo_trailing)


### PR DESCRIPTION
I added some features that allow you to POST/PUT json directly to APIs, as well as modify the URLs via patterns in your models.

This is helpful for:

- Calling APIs that don't fit nicely with the REST / CRUD paradigm.
- Transforming non REST / CRUD legacy APIs into REST / CRUD APIs useful to MVC frameworks.
- Calling APIs that require JSON as their body payload instead of parameters.

I also added the ability to pass custom headers and optionally remove the trailing '/' from REST urls as some legacy APIs didn't route correctly with a trailing '/'
